### PR TITLE
chore: upgrade circleCI node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: node:8
+      - image: node:14.15.0
 
     dependencies:
       pre:
@@ -29,7 +29,7 @@ jobs:
 
   deploy:
     docker:
-      - image: node:8
+      - image: node:14.15.0
 
     steps:
       - checkout


### PR DESCRIPTION
After the latest semantic-release pacjage upgrade builds fail with `[semantic-release]: node version >=10.18 is required. Found v8.17.0.`

This PR fixes this problem by upgrading the node version. 

Signed-off-by: Maria Paktiti <maria.paktiti@gmail.com>