### PR TITLE
chore: fix circleCI configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,9 @@
     }
   },
   "release": {
-    "branch": "master"
+    "branches": [
+      "master"
+    ]
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
       ]
     }
   },
+  "release": {
+    "branch": "master"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Latest semanticc-release upgrade broke builds. I think that this repo will keep on failing because it's missing some permissions but in any case the configuration change needs to be in place. 